### PR TITLE
Feature/options reactance support

### DIFF
--- a/Source/MicrowaveNetworks/Touchstone/IO/TouchstoneReader.cs
+++ b/Source/MicrowaveNetworks/Touchstone/IO/TouchstoneReader.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.IO;

--- a/Source/MicrowaveNetworks/Touchstone/IO/TouchstoneWriter.cs
+++ b/Source/MicrowaveNetworks/Touchstone/IO/TouchstoneWriter.cs
@@ -118,7 +118,11 @@ namespace MicrowaveNetworks.Touchstone.IO
             string frequencyUnit = TouchstoneEnumMap<FrequencyUnit>.ToTouchstoneValue(options.FrequencyUnit);
             string parameter = TouchstoneEnumMap<ParameterType>.ToTouchstoneValue(options.Parameter);
             string format = TouchstoneEnumMap<FormatType>.ToTouchstoneValue(options.Format);
-            string resistance = $"{ResistanceChar} {options.Resistance:g}";
+            string sign = options.Reactance >= 0 ? "+" : "";
+            string resistance = options.Reactance == 0 ?
+                $"{ResistanceChar} {options.Resistance:g}" :
+                $"{ResistanceChar} ({options.Resistance:g}{sign}{options.Reactance:g}j)";
+
 
             return string.Join(" ", OptionChar, frequencyUnit, parameter, format, resistance);
         }

--- a/Source/MicrowaveNetworks/Touchstone/TouchstoneOptions.cs
+++ b/Source/MicrowaveNetworks/Touchstone/TouchstoneOptions.cs
@@ -13,9 +13,19 @@
         public ParameterType Parameter = ParameterType.Scattering;
         /// <summary>Specifies the format of the network paramater data pairs in the file.</summary>
         public FormatType Format = FormatType.MagnitudeAngle;
-        /// <summary>Specifies the reference resistance in ohms, where <see cref="Resistance"/> is a real, positive number of ohms.</summary>
+        /// <summary>
+        /// Specifies the reference resistance in ohms, where <see cref="Resistance"/> is a real, positive number of ohms.
+        /// If the <see cref="TouchstoneParameterAttribute"/> "R" is complex it will be represented by its real part. 
+        /// </summary>
         [TouchstoneParameter("R")]
         public float Resistance = 50;
+        /// <summary>
+        /// Specifies the reference reactance in ohms, where <see cref="Reactance"/> is a real number of ohms. 
+        /// If the <see cref="TouchstoneParameterAttribute"/> "R" is complex it will be represented by its imaginary part.
+        /// Otherwise it is considered to be 0.
+        /// </summary>
+        [TouchstoneParameter("R")]
+        public float Reactance = 0;
 
         /// <summary>
         /// Returns a new <see cref="TouchstoneOptions"/> with default values according to the specification.

--- a/Tests/ScatteringParametersTests/TouchstoneTests/TestCases.cs
+++ b/Tests/ScatteringParametersTests/TouchstoneTests/TestCases.cs
@@ -76,7 +76,7 @@ namespace MicrowaveNetworksTests.TouchstoneTests
                     FrequencyUnit = FrequencyUnit.MHz,
                     Parameter = ParameterType.Scattering,
                     Resistance = 75,
-                    Reactance = -20,
+                    Reactance = 20,
                     Format = FormatType.MagnitudeAngle
                 }),
             };

--- a/Tests/ScatteringParametersTests/TouchstoneTests/TestCases.cs
+++ b/Tests/ScatteringParametersTests/TouchstoneTests/TestCases.cs
@@ -15,6 +15,7 @@ namespace MicrowaveNetworksTests.TouchstoneTests
                     FrequencyUnit = FrequencyUnit.MHz,
                     Parameter = ParameterType.Scattering,
                     Resistance = 75,
+                    Reactance = 0,
                     Format = FormatType.MagnitudeAngle
                 }),
                 // Validates spacing with one or more whitespace characters
@@ -31,6 +32,7 @@ namespace MicrowaveNetworksTests.TouchstoneTests
                     FrequencyUnit = FrequencyUnit.Hz,
                     Parameter = ParameterType.Admittance,
                     Resistance = 50,
+                    Reactance = 0,
                     Format = FormatType.DecibelAngle
                 }),
                 // Different ordering #2
@@ -39,12 +41,14 @@ namespace MicrowaveNetworksTests.TouchstoneTests
                     FrequencyUnit = FrequencyUnit.GHz,
                     Parameter = ParameterType.HybridG,
                     Resistance = 50,
+                    Reactance = 0,
                     Format = FormatType.RealImaginary
                 }),
                 // Missing some values (valid per spec)
                 ("# R 75", new TouchstoneOptions
                 {
                     Resistance = 75,
+                    Reactance = 0,
                 }),
                 // Missing all values (valid per spec)
                 ("#", new TouchstoneOptions()),
@@ -54,7 +58,26 @@ namespace MicrowaveNetworksTests.TouchstoneTests
                     FrequencyUnit = FrequencyUnit.Hz,
                     Parameter = ParameterType.Scattering,
                     Resistance = 50,
+                    Reactance = 0,
                     Format = FormatType.DecibelAngle,
+                }),
+                // Standard complete header complex resistance
+                ("# MHz S MA R (75-20j)", new TouchstoneOptions
+                {
+                    FrequencyUnit = FrequencyUnit.MHz,
+                    Parameter = ParameterType.Scattering,
+                    Resistance = 75,
+                    Reactance = -20,
+                    Format = FormatType.MagnitudeAngle
+                }),
+                // Standard complete header complex resistance
+                ("# MHz S MA R (75+20j)", new TouchstoneOptions
+                {
+                    FrequencyUnit = FrequencyUnit.MHz,
+                    Parameter = ParameterType.Scattering,
+                    Resistance = 75,
+                    Reactance = -20,
+                    Format = FormatType.MagnitudeAngle
                 }),
             };
         }

--- a/Tests/ScatteringParametersTests/TouchstoneTests/TouchstoneFileTests.cs
+++ b/Tests/ScatteringParametersTests/TouchstoneTests/TouchstoneFileTests.cs
@@ -14,6 +14,12 @@ namespace MicrowaveNetworksTests.TouchstoneTests
     [TestClass]
     public class TouchstoneFileTests
     {
+        static TouchstoneReader OpenReaderFromText(string text)
+        {
+            StringReader reader = new StringReader(text);
+            return TouchstoneReader.Create(reader);
+        }
+
         [TestMethod]
         public void SimpleRoundTripTest()
         {
@@ -46,5 +52,45 @@ namespace MicrowaveNetworksTests.TouchstoneTests
                 ts.NetworkParameters[freq, 2, 1].Should().Be(result[freq, 2, 1]);
             }
         }
+        [TestMethod]
+        public void DetailedOptionsRoundTripTest()
+        {
+            TouchstoneOptions defaultOptions = new TouchstoneOptions
+            {
+                Format = FormatType.DecibelAngle,
+                FrequencyUnit = FrequencyUnit.GHz,
+                Parameter = ParameterType.Scattering,
+                Resistance = 50
+            };
+
+            string filePath = Path.GetTempFileName();
+
+            var ts = new Touchstone(2, defaultOptions);
+            int gain_dB = 0;
+            for (double f = 1e9; f <= 2e9; f += 0.1e9)
+            {
+                var gain = NetworkParameter.FromPolarDecibelDegree(gain_dB, 0);
+                ts.NetworkParameters[f, 2, 1] = gain;
+            }
+
+            foreach ((string header, TouchstoneOptions options) in TestCases.V1.HeaderMaps)
+            {
+                var reader = OpenReaderFromText(header);
+                if (reader.Options.Parameter == ParameterType.Scattering)
+                {
+                    ts.Options = options;
+                    reader.Options.Should().BeEquivalentTo(options);
+                    reader.Dispose();
+
+                    ts.Write(filePath);
+
+                    var touchstoneData = new Touchstone(filePath);
+
+                    touchstoneData.Options.Should().BeEquivalentTo(ts.Options);
+                }
+                
+            }
+        }
+
     }
 }

--- a/Tests/ScatteringParametersTests/TouchstoneTests/v1/ReaderTestsV1.cs
+++ b/Tests/ScatteringParametersTests/TouchstoneTests/v1/ReaderTestsV1.cs
@@ -44,6 +44,7 @@ namespace MicrowaveNetworksTests.TouchstoneTests
             FluentActions.Invoking(() => coll = FromText(SampleFiles.FourPort_v1)).Should().NotThrow();
             coll.NumberOfPorts.Should().Be(4);
         }
+
         [TestMethod]
         public void TestHeaderParsing()
         {


### PR DESCRIPTION
This is added for convenience as by default scikit-rf creates a complex valued resistance in the options header which looks like
"# Hz S RI R (50+0j) "

added Reactance parameter to Touchstone Options
added support for touch stone reader
added support for writer to only write complex if reactance !=0
