### PR TITLE
Fixed null Type Value for "INetworkParametersCollection.NetworkParameterType"

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore $env:SOURCE
     - name: Build

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -20,19 +20,14 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+            5.x
+            8.x
     - name: Restore dependencies
       run: dotnet restore $env:SOURCE
     - name: Build
       run: dotnet build $env:SOURCE --no-restore --configuration Release 
     - name: Test
-      run: dotnet test $env:TESTS --configuration Release
-    #- name: Pack
-    #  run: dotnet pack $env:SOURCE --no-build --configuration Release
-    #- name: Upload 
-    #  uses: actions/upload-artifact@v2
-    #  with:
-    #    name: nuget-package
-    #    path: Source/**/bin/Release/*.nupkg
+      run: dotnet test $env:TESTS --no-build --configuration Release

--- a/.github/workflows/finish-and-release.yml
+++ b/.github/workflows/finish-and-release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore $env:SOURCE
     - name: Build

--- a/.github/workflows/finish-and-release.yml
+++ b/.github/workflows/finish-and-release.yml
@@ -36,9 +36,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+            5.x
+            8.x
     - name: Restore dependencies
       run: dotnet restore $env:SOURCE
     - name: Build

--- a/Source/MicrowaveNetworks/Internal/Utilities.cs
+++ b/Source/MicrowaveNetworks/Internal/Utilities.cs
@@ -58,5 +58,84 @@ namespace MicrowaveNetworks.Internal
                 _ => throw new NotImplementedException($"Support for parameter type {p} has not been implemented."),
             };
         }
+
+
+        #region IList<T> Binary Helpers
+
+        // Below copied from https://stackoverflow.com/a/2948872
+
+        /// <summary>
+        /// Performs a binary search on the specified collection.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the item.</typeparam>
+        /// <typeparam name="TSearch">The type of the searched item.</typeparam>
+        /// <param name="list">The list to be searched.</param>
+        /// <param name="value">The value to search for.</param>
+        /// <param name="comparer">The comparer that is used to compare the value
+        /// with the list items.</param>
+        /// <returns></returns>
+        public static int BinarySearch<TItem, TSearch>(this IList<TItem> list,
+            TSearch value, Func<TSearch, TItem, int> comparer)
+        {
+            if (list == null)
+            {
+                throw new ArgumentNullException("list");
+            }
+            if (comparer == null)
+            {
+                throw new ArgumentNullException("comparer");
+            }
+
+            int lower = 0;
+            int upper = list.Count - 1;
+
+            while (lower <= upper)
+            {
+                int middle = lower + (upper - lower) / 2;
+                int comparisonResult = comparer(value, list[middle]);
+                if (comparisonResult < 0)
+                {
+                    upper = middle - 1;
+                }
+                else if (comparisonResult > 0)
+                {
+                    lower = middle + 1;
+                }
+                else
+                {
+                    return middle;
+                }
+            }
+
+            return ~lower;
+        }
+
+        /// <summary>
+        /// Performs a binary search on the specified collection.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the item.</typeparam>
+        /// <param name="list">The list to be searched.</param>
+        /// <param name="value">The value to search for.</param>
+        /// <returns></returns>
+        public static int BinarySearch<TItem>(this IList<TItem> list, TItem value)
+        {
+            return BinarySearch(list, value, Comparer<TItem>.Default);
+        }
+
+        /// <summary>
+        /// Performs a binary search on the specified collection.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the item.</typeparam>
+        /// <param name="list">The list to be searched.</param>
+        /// <param name="value">The value to search for.</param>
+        /// <param name="comparer">The comparer that is used to compare the value
+        /// with the list items.</param>
+        /// <returns></returns>
+        public static int BinarySearch<TItem>(this IList<TItem> list, TItem value,
+            IComparer<TItem> comparer)
+        {
+            return list.BinarySearch(value, comparer.Compare);
+        }
+        #endregion
     }
 }

--- a/Source/MicrowaveNetworks/MicrowaveNetworks.csproj
+++ b/Source/MicrowaveNetworks/MicrowaveNetworks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net5.0;net45;net8.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <OutputType>Library</OutputType>
     <Authors>Michael Whitten</Authors>

--- a/Source/MicrowaveNetworks/MicrowaveNetworks.csproj
+++ b/Source/MicrowaveNetworks/MicrowaveNetworks.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/mdwhitten/microwave-networks</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/mdwhitten/microwave-networks</PackageProjectUrl>
     <DocumentationFile>bin\MicrowaveNetworks.xml</DocumentationFile>
@@ -17,7 +17,6 @@
     <Description>A library implementing common tools for working with microwave networks including reading/writing to Touchstone (.snp) files, de/embedding network parameters, etc.</Description>
     <Copyright>Copyright ©  2021</Copyright>
     <Product>Microwave Networks</Product>
-    <Company>NI</Company>
     <GenerateAssemblyCompanyAttribute>True</GenerateAssemblyCompanyAttribute>
   </PropertyGroup>
   <PropertyGroup>
@@ -32,18 +31,12 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="C5" Version="2.5.3" />
     <PackageReference Include="MathNet.Numerics">
       <Version>4.15.0</Version>
     </PackageReference>
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'">

--- a/Source/MicrowaveNetworks/NetworkParametersCollection.cs
+++ b/Source/MicrowaveNetworks/NetworkParametersCollection.cs
@@ -128,7 +128,6 @@ namespace MicrowaveNetworks
         IReadOnlyCollection<NetworkParametersMatrix> INetworkParametersCollection.NetworkParameters => NetworkParameters;
         /// <summary>Gets the specific subtype of <see cref="NetworkParametersMatrix"/> represented by this collection.</summary>
         /// <remarks>This collection is often created from a file and so the network parameter matrix type will not be known until after this object is created.</remarks>
-        public Type NetworkParameterType { get; }
         Type INetworkParametersCollection.NetworkParameterType => typeof(TMatrix);
 
         /// <summary>

--- a/Source/MicrowaveNetworks/NetworkParametersCollection.cs
+++ b/Source/MicrowaveNetworks/NetworkParametersCollection.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Collections;
-using SCG = System.Collections.Generic;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
-using C5;
 using MathNet.Numerics.Interpolation;
 using MicrowaveNetworks.Matrices;
 using MicrowaveNetworks.Touchstone.IO;
@@ -35,12 +33,12 @@ namespace MicrowaveNetworks
             Parameters = parameters;
         }
 
-        /// <summary>Creates a <see cref="FrequencyParametersPair"/> from a <see cref="SCG.KeyValuePair{TKey, TValue}"/> object.</summary>
-        public static implicit operator FrequencyParametersPair(SCG.KeyValuePair<double, NetworkParametersMatrix> pair)
+        /// <summary>Creates a <see cref="FrequencyParametersPair"/> from a <see cref="KeyValuePair{TKey, TValue}"/> object.</summary>
+        public static implicit operator FrequencyParametersPair(KeyValuePair<double, NetworkParametersMatrix> pair)
             => new FrequencyParametersPair(pair.Key, pair.Value);
-        /// <summary>Creates a <see cref="SCG.KeyValuePair{TKey, TValue}"/> from a <see cref="FrequencyParametersPair"/> object.</summary>
-        public static implicit operator SCG.KeyValuePair<double, NetworkParametersMatrix>(FrequencyParametersPair pair)
-            => new SCG.KeyValuePair<double, NetworkParametersMatrix>(pair.Frequency_Hz, pair.Parameters);
+        /// <summary>Creates a <see cref="KeyValuePair{TKey, TValue}"/> from a <see cref="FrequencyParametersPair"/> object.</summary>
+        public static implicit operator KeyValuePair<double, NetworkParametersMatrix>(FrequencyParametersPair pair)
+            => new KeyValuePair<double, NetworkParametersMatrix>(pair.Frequency_Hz, pair.Parameters);
 
         /// <summary>
         /// Adds support for the ValueTuple deconstruction syntax for this object.
@@ -71,12 +69,12 @@ namespace MicrowaveNetworks
             Parameters = parameters;
         }
 
-        /// <summary>Creates a <see cref="FrequencyParametersPair"/> from a <see cref="SCG.KeyValuePair{TKey, TValue}"/> object.</summary>
-        public static implicit operator FrequencyParametersPair<TMatrix>(SCG.KeyValuePair<double, TMatrix> pair)
+        /// <summary>Creates a <see cref="FrequencyParametersPair"/> from a <see cref="KeyValuePair{TKey, TValue}"/> object.</summary>
+        public static implicit operator FrequencyParametersPair<TMatrix>(KeyValuePair<double, TMatrix> pair)
             => new FrequencyParametersPair<TMatrix>(pair.Key, pair.Value);
-        /// <summary>Creates a <see cref="SCG.KeyValuePair{TKey, TValue}"/> from a <see cref="FrequencyParametersPair"/> object.</summary>
-        public static implicit operator SCG.KeyValuePair<double, TMatrix>(FrequencyParametersPair<TMatrix> pair)
-            => new SCG.KeyValuePair<double, TMatrix>(pair.Frequency_Hz, pair.Parameters);
+        /// <summary>Creates a <see cref="KeyValuePair{TKey, TValue}"/> from a <see cref="FrequencyParametersPair"/> object.</summary>
+        public static implicit operator KeyValuePair<double, TMatrix>(FrequencyParametersPair<TMatrix> pair)
+            => new KeyValuePair<double, TMatrix>(pair.Frequency_Hz, pair.Parameters);
 
         /// <summary>
         /// Adds support for the ValueTuple deconstruction syntax for this object.
@@ -107,23 +105,24 @@ namespace MicrowaveNetworks
     /// <typeparam name="TMatrix">Specifies the network parameter type contained within this collection.</typeparam>
     public sealed class NetworkParametersCollection<TMatrix> : INetworkParametersCollection where TMatrix : NetworkParametersMatrix
     {
-        private readonly Dictionary<double, TMatrix> networkParameters;
-        private readonly SortedArray<double> frequencies;
+        //private readonly Dictionary<double, TMatrix> networkParameters;
+        //private readonly SortedArray<double> frequencies;
+        private readonly SortedList<double, TMatrix> networkParameters;
 
         /// <summary>Gets the number of ports of the device that this collection represents.</summary>
         public int NumberOfPorts { get; }
         /// <summary>Gets all frequencies defined in this collection in Hz.</summary>
 
-#if NET45
-        public IReadOnlyCollection<double> Frequencies => networkParameters.Keys.ToList().AsReadOnly();
+#if NET8_0_OR_GREATER
+        public IReadOnlyCollection<double> Frequencies => networkParameters.Keys.AsReadOnly();
 #else
-        public IReadOnlyCollection<double> Frequencies => networkParameters.Keys;
+        public IReadOnlyCollection<double> Frequencies => new ReadOnlyCollection<double>(networkParameters.Keys);
 #endif
         /// <summary>Gets all the network parameters defined in this collection.</summary>
-#if NET45
-        public IReadOnlyCollection<TMatrix> NetworkParameters => networkParameters.Values.ToList().AsReadOnly();
+#if NET8_0_OR_GREATER
+        public IReadOnlyCollection<TMatrix> NetworkParameters => networkParameters.Values.AsReadOnly();
 #else
-        public IReadOnlyCollection<TMatrix> NetworkParameters => networkParameters.Values;
+        public IReadOnlyCollection<TMatrix> NetworkParameters => new ReadOnlyCollection<TMatrix>(networkParameters.Values);
 #endif
         IReadOnlyCollection<NetworkParametersMatrix> INetworkParametersCollection.NetworkParameters => NetworkParameters;
         /// <summary>Gets the specific subtype of <see cref="NetworkParametersMatrix"/> represented by this collection.</summary>
@@ -137,8 +136,7 @@ namespace MicrowaveNetworks
         public NetworkParametersCollection(int numPorts)
         {
             NumberOfPorts = numPorts;
-            networkParameters = new Dictionary<double, TMatrix>();
-            frequencies = new SortedArray<double>();
+            networkParameters = new SortedList<double, TMatrix>();
         }
         /// <summary>
         /// Creates a new network parameters collection from a seqeunce of frequency and network parameter matrix pairs.
@@ -160,22 +158,15 @@ namespace MicrowaveNetworks
         }
 
         /// <summary>
-        /// Creates a new <see cref="NetworkParametersCollection{TMatrix}"/> from an existing <see cref="SCG.IList{T}"/> of 
+        /// Creates a new <see cref="NetworkParametersCollection{TMatrix}"/> from an existing <see cref="IList{T}"/> of 
         /// <see cref="FrequencyParametersPair{TMatrix}"/> pairs.
         /// </summary>
         /// <param name="parameters">The list of parameters </param>
         /// <param name="sorted"></param>
-        public NetworkParametersCollection(SCG.IList<FrequencyParametersPair<TMatrix>> parameters, bool sorted = false)
+        public NetworkParametersCollection(IList<FrequencyParametersPair<TMatrix>> parameters, bool sorted = false)
         {
-            networkParameters = new Dictionary<double, TMatrix>(parameters.Count);
-            frequencies = new SortedArray<double>(parameters.Count);
-
-            foreach (var (frequency, data) in parameters)
-            {
-                networkParameters[frequency] = data;
-                if (!sorted) frequencies.Add(frequency);
-            }
-            if (sorted) frequencies.AddSorted(parameters.Select(p => p.Frequency_Hz));
+            var dictionary = parameters.ToDictionary(el => el.Frequency_Hz, el => el.Parameters);
+            networkParameters = new SortedList<double, TMatrix>(dictionary);
         }
 
         /// <summary>
@@ -205,7 +196,6 @@ namespace MicrowaveNetworks
                     throw new ArgumentException("All network parameter matrices must have the same number of ports.");
                 }
                 networkParameters[frequency] = value;
-                frequencies.Add(frequency);
             }
         }
 
@@ -232,7 +222,6 @@ namespace MicrowaveNetworks
                     TMatrix matrix = (TMatrix)Activator.CreateInstance(typeof(TMatrix), NumberOfPorts);
                     matrix[destinationPort, sourcePort] = value;
                     networkParameters.Add(frequency, matrix);
-                    frequencies.Add(frequency);
                 }
             }
         }
@@ -241,25 +230,36 @@ namespace MicrowaveNetworks
         /// <returns>The <see cref="NetworkParametersMatrix"/> at or nearest to <paramref name="frequency"/>.</returns>
         public TMatrix Nearest(double frequency)
         {
-            bool predecessorFound = frequencies.TryWeakPredecessor(frequency, out double predecessor);
-            bool successorFound = frequencies.TryWeakSuccessor(frequency, out double successor);
+            bool found = networkParameters.TryGetValue(frequency, out TMatrix value);
+            if (!found)
+            {
+                // Keys is cached by the sorted list implementation and not regenerated each time
+                int location = networkParameters.Keys.BinarySearch(frequency);
 
-            if (predecessorFound && successorFound)
-            {
-                double preDelta = Math.Abs(predecessor - frequency);
-                double postDelta = Math.Abs(successor - frequency);
+                location = ~location;
 
-                return preDelta < postDelta ? this[predecessor] : this[successor];
+                if (location == 0)
+                {
+                    return networkParameters.Values.First();
+                }
+                else if (location >= networkParameters.Count)
+                {
+                    return networkParameters.Values.Last();
+                }
+                else
+                {
+                    int predecssorLocation = location - 1;
+
+                    double predecessor = networkParameters.Keys[predecssorLocation];
+                    double successor = networkParameters.Keys[location];
+
+                    double preDelta = Math.Abs(predecessor - frequency);
+                    double postDelta = Math.Abs(successor - frequency);
+
+                    return preDelta < postDelta ? this[predecessor] : this[successor];
+                }
             }
-            else if (predecessorFound)
-            {
-                return this[predecessor];
-            }
-            else if (successorFound)
-            {
-                return this[successor];
-            }
-            throw new ArgumentOutOfRangeException(nameof(frequency));
+            else return value;
         }
         NetworkParametersMatrix INetworkParametersCollection.Nearest(double frequency) => Nearest(frequency);
         /// <summary>Gets the number of <see cref="FrequencyParametersPair"/> objects contained in the collection.</summary>
@@ -283,7 +283,6 @@ namespace MicrowaveNetworks
         public void Clear()
         {
             networkParameters.Clear();
-            frequencies.Clear();
         }
         /// <summary>
         /// Attempts to remove the <see cref="NetworkParametersMatrix"/> at the specified frequency from the collection.
@@ -292,9 +291,7 @@ namespace MicrowaveNetworks
         /// <returns>True if the element is successfully found and removed; false if not.</returns>
         public bool Remove(double frequency)
         {
-            bool one = networkParameters.Remove(frequency);
-            bool two = frequencies.Remove(frequency);
-            return one & two;
+           return networkParameters.Remove(frequency);
         }
         /// <summary>
         /// Gets the <see cref="NetworkParametersMatrix"/> associated with the specified frequency.
@@ -346,7 +343,7 @@ namespace MicrowaveNetworks
         }
 
         #region Explicit ICollection Implementations
-        bool SCG.ICollection<FrequencyParametersPair>.IsReadOnly => false;
+        bool ICollection<FrequencyParametersPair>.IsReadOnly => false;
 
 
         NetworkParametersMatrix INetworkParametersCollection.this[double frequency]
@@ -356,7 +353,7 @@ namespace MicrowaveNetworks
         }
 
 
-        bool SCG.ICollection<FrequencyParametersPair>.Contains(FrequencyParametersPair item)
+        bool ICollection<FrequencyParametersPair>.Contains(FrequencyParametersPair item)
         {
             if (networkParameters.TryGetValue(item.Frequency_Hz, out TMatrix value))
             {
@@ -365,13 +362,13 @@ namespace MicrowaveNetworks
             else return false;
         }
 
-        void SCG.ICollection<FrequencyParametersPair>.CopyTo(FrequencyParametersPair[] array, int arrayIndex)
+        void ICollection<FrequencyParametersPair>.CopyTo(FrequencyParametersPair[] array, int arrayIndex)
         {
-            var arr = Array.ConvertAll(array, f => (SCG.KeyValuePair<double, NetworkParametersMatrix>)f);
-            ((SCG.ICollection<SCG.KeyValuePair<double, NetworkParametersMatrix>>)networkParameters).CopyTo(arr, arrayIndex);
+            var arr = Array.ConvertAll(array, f => (KeyValuePair<double, NetworkParametersMatrix>)f);
+            ((ICollection<KeyValuePair<double, NetworkParametersMatrix>>)networkParameters).CopyTo(arr, arrayIndex);
         }
 
-        bool SCG.ICollection<FrequencyParametersPair>.Remove(FrequencyParametersPair item)
+        bool ICollection<FrequencyParametersPair>.Remove(FrequencyParametersPair item)
         {
             return Remove(item.Frequency_Hz);
         }
@@ -391,7 +388,7 @@ namespace MicrowaveNetworks
             return found;
         }
 
-        void SCG.ICollection<FrequencyParametersPair>.Add(FrequencyParametersPair item) => Add(item.Frequency_Hz, item.Parameters.ConvertParameterType<TMatrix>());
+        void ICollection<FrequencyParametersPair>.Add(FrequencyParametersPair item) => Add(item.Frequency_Hz, item.Parameters.ConvertParameterType<TMatrix>());
 
         IEnumerator<FrequencyParametersPair> IEnumerable<FrequencyParametersPair>.GetEnumerator()
         {

--- a/Tests/ScatteringParametersTests/MicrowaveNetworksTests.csproj
+++ b/Tests/ScatteringParametersTests/MicrowaveNetworksTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net472;net5.0;net8.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>

--- a/Tests/ScatteringParametersTests/NetworkParametersCollectionTests.cs
+++ b/Tests/ScatteringParametersTests/NetworkParametersCollectionTests.cs
@@ -9,29 +9,29 @@ namespace MicrowaveNetworksTests
     [TestClass]
     public class NetworkParametersCollectionTests
     {
-        [TestMethod]
-        public void TestNearest()
+        static NetworkParametersCollection<ScatteringParametersMatrix> collection;
+
+        [ClassInitialize]
+        public static void Setup(TestContext context)
         {
-            var collection = new NetworkParametersCollection<ScatteringParametersMatrix>(2);
+            collection = new NetworkParametersCollection<ScatteringParametersMatrix>(2);
             for (int i = 1; i <= 20; i++)
             {
                 collection[i * 1.0e9, 2, 1] = NetworkParameter.FromPolarDecibelDegree(i, 0);
             }
 
-            collection.Nearest(0)[2, 1].Should().Be(NetworkParameter.FromPolarDecibelDegree(1, 0), 
-                "0 is out of bounds but closest to 1e9");
+        }
 
-            collection.Nearest(1.0e9)[2, 1].Should().Be(NetworkParameter.FromPolarDecibelDegree(1, 0), 
-                "1e9 is equal to 1e9");
+        [TestMethod]
+        [DataRow(0, 1)]
+        [DataRow(1.0e9, 1)]
+        [DataRow(1.51e9, 2)]
+        [DataRow(19.9e9, 20)]
+        [DataRow(21e9, 20)]
+        public void TestNearest(double testFrequency, double exptedMagnitude)
+        {
 
-            collection.Nearest(1.51e9)[2, 1].Should().Be(NetworkParameter.FromPolarDecibelDegree(2, 0),
-                "1.51e9 is closer to 2e9");
-
-            collection.Nearest(19.9e9)[2, 1].Should().Be(NetworkParameter.FromPolarDecibelDegree(20, 0),
-                "19.9e9 is nearest to 20e9");
-
-            collection.Nearest(21e9)[2, 1].Should().Be(NetworkParameter.FromPolarDecibelDegree(20, 0),
-                "21e9 is outside of bounds but nearest to 20e9");
+            collection.Nearest(testFrequency)[2, 1].Should().Be(NetworkParameter.FromPolarDecibelDegree(exptedMagnitude, 0));
 
         }
     }

--- a/Tests/ScatteringParametersTests/TouchstoneTests/v1/WriterTestsV1.cs
+++ b/Tests/ScatteringParametersTests/TouchstoneTests/v1/WriterTestsV1.cs
@@ -107,8 +107,14 @@ namespace MicrowaveNetworksTests.TouchstoneTests
             {
                 sb.Append($"\t{{{i + 1}:{numericFormat}}}");
             }
+
+#if NET45
+            var prepended = (new double[] { frequency }).Concat(dataLines);
             
+            return string.Format(sb.ToString(), prepended.Cast<object>().ToArray());
+#else
             return string.Format(sb.ToString(), dataLines.Prepend(frequency).Cast<object>().ToArray());
+#endif
         }
     }
 }


### PR DESCRIPTION
Removed extraneous extra definition of property that was undefined, causing exceptions to be thrown when trying to convert from the INetworkParametersCollection type.